### PR TITLE
Prefer python3

### DIFF
--- a/plugin/indenty.vim
+++ b/plugin/indenty.vim
@@ -1,4 +1,4 @@
-if !(has ('python') || has('python3')) || &compatible || exists("g:loaded_indenty")
+if !(has('python3') || has('python')) || &compatible || exists("g:loaded_indenty")
     finish
 endif
 let g:loaded_indenty = 1


### PR DESCRIPTION
Check for python3 before checking for python.

Latest vim versions disallow using python2 and python3 at once, when you start using one version it is not possible to use any other.

Checking the type of support is enough to disable the other python version, for example:
```
echo has('python')
echo has ('python3')
```

Produces
```
1
0
```

And

```
echo has('python3')
echo has ('python')
```

Produces
```
1
0
```

So the order of the checks matters.

Since most of the plugins nowadays use python3, this change allows them to work together if indenty is loaded first.